### PR TITLE
vesselid is added automatically if a portcallmessage comes in with it

### DIFF
--- a/App/src/main/java/softproject/controllers/SubscriptionController.java
+++ b/App/src/main/java/softproject/controllers/SubscriptionController.java
@@ -59,6 +59,21 @@ public class SubscriptionController {
     public List<PortCallMessage> newQueue(@PathVariable String queueId) {
         SubscriptionService subService = new SubscriptionService();
         List<PortCallMessage> result = subService.getNewMessages(queueId);
+
+        PortCallRepository repo = PortCallRepository.getRepo();
+        PortCall portcall = repo.getFromQueueId(queueId);
+
+        if(portcall != null && portcall.getVesselId() != null && portcall.getVesselId().length() <= 0) {
+            for(PortCallMessage m : result) {
+                if(m.getVesselId() != null && m.getVesselId().length() > 0) {
+                    portcall.setVesselId(m.getVesselId());
+                    repo.add(portcall);
+                    break;
+                }
+            }
+        }
+
+
         System.out.println("New Queue " + result);
         return result;
     }


### PR DESCRIPTION
Vessel Id added automatically.
The reverse isn't a good idea, the same vessel Id can have multiple portcalls at the same time